### PR TITLE
fix: Syntax to search for 'rule_label' value name

### DIFF
--- a/modules/rule-group/main.tf
+++ b/modules/rule-group/main.tf
@@ -36,7 +36,7 @@ resource "aws_wafv2_rule_group" "this" {
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) == null ? [] : [lookup(rule.value, "rule_label")]
         content {
-          name = lookup(rule.value, "rule_label")
+          name = lookup(rule_label.value, "name")
         }
       }
 


### PR DESCRIPTION
Corrected the lookup syntax to search for the rule_label value by name.






