### PR TITLE
fix: rule_action_override challenge config condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -200,7 +200,7 @@ resource "aws_wafv2_web_acl" "this" {
                       content {}
                     }
                     dynamic "challenge" {
-                      for_each = action_to_use.value == "count" ? [1] : []
+                      for_each = action_to_use.value == "challenge" ? [1] : []
                       content {}
                     }
                   }


### PR DESCRIPTION
Fixes #14 

This pull request includes a correction to the `aws_wafv2_web_acl` resource definition in the `main.tf` file. The change ensures that the `challenge` dynamic block is used correctly based on the `action_to_use` value.

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL203-R203): Fixed the condition for the `challenge` dynamic block to check if `action_to_use.value` equals "challenge" instead of "count".