### PR TITLE
fix: Logging configuration redacted_fields support multiple conditions

### DIFF
--- a/examples/LoggingConfiguration/main.tf
+++ b/examples/LoggingConfiguration/main.tf
@@ -11,7 +11,13 @@ module "logging_configuration" {
   enabled_logging_configuration = true
   log_destination_configs       = ""
   redacted_fields = {
-    uri_path = {}
+    single_header = {
+      authorization  = { name = "authorization" },
+      x-other-header = { name = "x-other-header" },
+    }
+    method       = {}
+    query_string = {}
+    uri_path     = {}
   }
   logging_filter = {
     default_behavior = "DROP"

--- a/main.tf
+++ b/main.tf
@@ -12239,29 +12239,35 @@ resource "aws_wafv2_web_acl_logging_configuration" "this" {
   resource_arn            = aws_wafv2_web_acl.this.arn
 
   dynamic "redacted_fields" {
-    for_each = var.redacted_fields == null ? [] : [var.redacted_fields]
+    for_each = try(var.redacted_fields.single_header, [])
     content {
       dynamic "single_header" {
-        for_each = lookup(redacted_fields.value, "single_header", null) == null ? [] : [lookup(redacted_fields.value, "single_header")]
+        for_each = [redacted_fields.value]
         content {
-          name = lower(lookup(single_header.value, "name"))
+          name = lower(single_header.value.name)
         }
       }
+    }
+  }
 
-      dynamic "method" {
-        for_each = lookup(redacted_fields.value, "method", null) == null ? [] : [lookup(redacted_fields.value, "method")]
-        content {}
-      }
+  dynamic "redacted_fields" {
+    for_each = contains(keys(var.redacted_fields), "method") ? [1] : []
+    content {
+      method {}
+    }
+  }
 
-      dynamic "query_string" {
-        for_each = lookup(redacted_fields.value, "query_string", null) == null ? [] : [lookup(redacted_fields.value, "query_string")]
-        content {}
-      }
+  dynamic "redacted_fields" {
+    for_each = contains(keys(var.redacted_fields), "query_string") ? [1] : []
+    content {
+      query_string {}
+    }
+  }
 
-      dynamic "uri_path" {
-        for_each = lookup(redacted_fields.value, "uri_path", null) == null ? [] : [lookup(redacted_fields.value, "uri_path")]
-        content {}
-      }
+  dynamic "redacted_fields" {
+    for_each = contains(keys(var.redacted_fields), "uri_path") ? [1] : []
+    content {
+      uri_path {}
     }
   }
 


### PR DESCRIPTION
This is a fix for the `aws_wafv2_web_acl_logging_configuration` resource `redacted_fields` configuration. 

#### 1. The `redacted_fields` [can only specify one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration#redacted-fields) of the following: `method`, `query_string`, `single_header`, or `uri_path`.

The fix here is to create multiple `redacted_fields` blocks, each only having a single configuration block. In the current implementation if more than one condition is specified, apply fails with `EXACTLY_ONE_CONDITION_REQUIRED, field: FIELD_TO_MATCH, parameter: FieldToMatch`

#### 2. The `single_header` block can be specified multiple times, but again [one for each](https://github.com/hashicorp/terraform-provider-aws/issues/14249) `redacted_fields` block.

The current implementation would only take account one `single_header` value, ignoring all others defined.

Since module `var.redacted_fields` can only have consistent types, the configuration of this parameter was updated to the form `single_header = {header1  = { name = "authorization" }, header2 = { name = "x-other-header" }}` (examples updated)

Is is worth pointing out that this would be a breaking change for anyone using `single_header` with current syntax, as that would have to change to the one described in the example. 

This was the best approach I could think of @uyggnodoow, happy to get your feedback on this.