### PR TITLE
fix: custom_key always yields an empty list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8098,7 +8098,7 @@ resource "aws_wafv2_web_acl" "this" {
               }
             }
             dynamic "custom_key" {
-              for_each = lookup(rate_based_statement.value, "custom_key", null) == null ? [] : lookup(rate_based_statement.value, "custom_key")
+              for_each = lookup(rate_based_statement.value, "custom_key", [])
               iterator = custom_key
 
               content {


### PR DESCRIPTION
Due to type inference terraform does under the hood, some combinations can unify, like `[ { uri_path=… }, { ip={} } ]` into a single “list of objects” type and treat it as a “list” (so it auto-widens [] to match and no error). But when you do `[ { cookie=… }, { ip={} } ],` the shapes of those two map-objects don’t unify in exactly the same way, so Terraform falls back to treating them as a 2-tuple literal, hence the problem bellow.

```
│ Error: Inconsistent conditional result types
│
│   on .terraform/modules/waf.web_acl/main.tf line 8101, in resource "aws_wafv2_web_acl" "this":
│ 8101:               for_each = lookup(rate_based_statement.value, "custom_key", null) == null ? [] : lookup(rate_based_statement.value, "custom_key")
│     ├────────────────
│     │ rate_based_statement.value is object with 4 attributes
│
│ The true and false result expressions must have consistent types. The 'true' tuple has length 0, but the 'false' tuple has length 2.
```