### PR TITLE
Fix: custom response body can't support multiple inputs

### DIFF
--- a/examples/CustomResponse/main.tf
+++ b/examples/CustomResponse/main.tf
@@ -39,9 +39,10 @@ module "wafv2" {
   ]
 
   custom_response_body = {
-    key          = "CustomResponseBody",
-    content      = "Not authorized",
-    content_type = "TEXT_PLAIN"
+    "CustomResponseBody" = {
+      content      = "Not authorized",
+      content_type = "TEXT_PLAIN"
+    }
   }
 
   visibility_config = {

--- a/main.tf
+++ b/main.tf
@@ -12196,9 +12196,9 @@ resource "aws_wafv2_web_acl" "this" {
   dynamic "custom_response_body" {
     for_each = var.custom_response_body
     content {
-      content      = var.custom_response_body.content
-      content_type = var.custom_response_body.content_type
-      key          = var.custom_response_body.key
+      content      = custom_response_body.value.content
+      content_type = custom_response_body.value.content_type
+      key          = custom_response_body.key
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,8 +26,11 @@ variable "visibility_config" {
 
 variable "custom_response_body" {
   description = "(Optional) Defines custom response bodies that can be referenced by custom_response actions."
-  type        = map(any)
-  default     = {}
+  type = map(object({
+    content      = string
+    content_type = string
+  }))
+  default = {}
 }
 
 variable "captcha_config" {


### PR DESCRIPTION
The "custom_response_body" dynamic resource in the web_acl module can't support multiple custom_response_body inputs, which can be required in some cases.

Ive adjusted the input variable to accept a map of objects and adjusted the example accordingly.