### PR TITLE
feat: extending custom response handling

### DIFF
--- a/examples/CustomResponse/main.tf
+++ b/examples/CustomResponse/main.tf
@@ -13,6 +13,16 @@ module "wafv2" {
   name           = "WebACL01"
   scope          = "REGIONAL"
   default_action = "block"
+  default_custom_response = {
+    response_code            = 418
+    custom_response_body_key = "CustomResponseBody1"
+    response_header = [
+      {
+        name  = "X-Teapot-Protocol"
+        value = "true"
+      }
+    ]
+  }
   rule = [
     {
       name     = "Rule01"

--- a/examples/ManagedRuleGroupStatement/main.tf
+++ b/examples/ManagedRuleGroupStatement/main.tf
@@ -26,7 +26,21 @@ module "wafv2" {
         rule_action_override = [
           {
             name          = "NoUserAgent_HEADER"
-            action_to_use = "captcha"
+            action_to_use = "block"
+            custom_response = {
+              response_code            = 400
+              custom_response_body_key = "CustomResponseBody2"
+              response_header = [
+                {
+                  name  = "X-Custom-Response-Header01"
+                  value = "Not authorized"
+                },
+                {
+                  name  = "X-Custom-Response-Header02"
+                  value = "Not authorized"
+                }
+              ]
+            }
           },
           {
             name          = "UserAgent_BadBots_HEADER"
@@ -49,6 +63,19 @@ module "wafv2" {
         metric_name                = "cloudwatch_metric_name"
         sampled_requests_enabled   = false
       }
+    }
+  ]
+
+  custom_response_body = [
+    {
+      key          = "CustomResponseBody1",
+      content      = "Not authorized1",
+      content_type = "TEXT_PLAIN"
+    },
+    {
+      key          = "CustomResponseBody2",
+      content      = "Not authorized2",
+      content_type = "TEXT_PLAIN"
     }
   ]
   visibility_config = {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,25 @@ resource "aws_wafv2_web_acl" "this" {
     }
     dynamic "block" {
       for_each = var.default_action == "block" ? [1] : []
-      content {}
+      content {
+        dynamic "custom_response" {
+          for_each = var.default_custom_response == null ? [] : [var.default_custom_response]
+          content {
+            custom_response_body_key = lookup(custom_response.value, "custom_response_body_key", null)
+            response_code            = lookup(custom_response.value, "response_code", 403)
+
+            dynamic "response_header" {
+              for_each = lookup(custom_response.value, "response_header", [])
+              iterator = response_header
+
+              content {
+                name  = response_header.value.name
+                value = response_header.value.value
+              }
+            }
+          }
+        }
+      }
     }
   }
 
@@ -265,7 +283,25 @@ resource "aws_wafv2_web_acl" "this" {
                     }
                     dynamic "block" {
                       for_each = action_to_use.value == "block" ? [1] : []
-                      content {}
+                      content {
+                        dynamic "custom_response" {
+                          for_each = lookup(rule_action_override.value, "custom_response", null) == null ? [] : [lookup(rule_action_override.value, "custom_response")]
+                          content {
+                            custom_response_body_key = lookup(custom_response.value, "custom_response_body_key", null)
+                            response_code            = lookup(custom_response.value, "response_code", 403)
+
+                            dynamic "response_header" {
+                              for_each = lookup(custom_response.value, "response_header", [])
+                              iterator = response_header
+
+                              content {
+                                name  = response_header.value.name
+                                value = response_header.value.value
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                     dynamic "captcha" {
                       for_each = action_to_use.value == "captcha" ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,19 @@ variable "default_action" {
   type        = string
 }
 
+variable "default_custom_response" {
+  description = "(Optional) Customise the response when the default action is block"
+  type = object({
+    response_code            = optional(number, 403)
+    custom_response_body_key = optional(string)
+    response_header          = optional(list(object({
+      name  = string
+      value = string
+    })))
+  })
+  default = null
+}
+
 variable "association_config" {
   description = "(Optional) Customizes the request body that your protected resource forward to AWS WAF for inspection."
   type        = map(any)


### PR DESCRIPTION
- Adding support for a custom response when our default action is block.
- Adding support for a custom response for managed rules, when their rule action override is block.
- Adding examples for documentation.