### PR TITLE
fix(managed_rule_group): custom_response handling - code

### DIFF
--- a/examples/ManagedRuleGroupStatement/main.tf
+++ b/examples/ManagedRuleGroupStatement/main.tf
@@ -37,13 +37,21 @@ module "wafv2" {
                 },
                 {
                   name  = "X-Custom-Response-Header02"
-                  value = "Not authorized"
+                  value = "Access denied"
                 }
               ]
             }
           },
           {
             name          = "UserAgent_BadBots_HEADER"
+            action_to_use = "block"
+            custom_response = {
+              response_code            = 403
+              custom_response_body_key = "CustomResponseBody1"
+            }
+          },
+          {
+            name          = "SizeRestrictions_BODY"
             action_to_use = "captcha"
           }
         ]

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ resource "aws_wafv2_web_acl" "this" {
             }
 
             dynamic "rule_action_override" {
-              for_each = lookup(managed_rule_group_statement.value, "rule_action_override", null) == null ? [] : lookup(managed_rule_group_statement.value, "rule_action_override")
+              for_each = lookup(managed_rule_group_statement.value, "rule_action_override", [])
               content {
                 name = lookup(rule_action_override.value, "name")
 


### PR DESCRIPTION
Code-based fix for https://github.com/aws-ss/terraform-aws-wafv2/issues/30. We can avoid defining a type or documenting counter-intuitive workarounds by introducing a more efficient but inconsistent pattern into tests for attributes in main/tf.