### PR TITLE
feat: add support for cloudfront in association_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,13 @@ resource "aws_wafv2_web_acl" "this" {
               default_size_inspection_limit = request_body.value.verified_access_instance.default_size_inspection_limit
             }
           }
+
+          dynamic "cloudfront" {
+            for_each = lookup(request_body.value, "cloudfront", null) == null ? [] : [1]
+            content {
+              default_size_inspection_limit = request_body.value.cloudfront.default_size_inspection_limit
+            }
+          }
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFront request body inspection configuration options, enabling users to specify the default size inspection limit for request body examination in WAFv2 web ACLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->